### PR TITLE
Correctly handle array responses from /tagged endpoint

### DIFF
--- a/pytumblr2/__init__.py
+++ b/pytumblr2/__init__.py
@@ -743,11 +743,23 @@ class TumblrRestClient(object):
             response = self.request.put(url, params)
         else:
             response = self.request.post(url, params, files)
+        
+        if isinstance(response, list):
+            # use presence of "post_url" key as proxy for testing if list objects are posts. this
+            # doesn't handle the case that the list is heterogeneous but surely not even tumblr
+            # would ever publish such a chaotic api as to return a heterogeneous list
+            if all("post_url" in p for p in response):
+                if self.convert_npf_to_legacy_html:
+                    response = [simulate_legacy_payload(p) for p in response]
+                posts_to_cache = response
+            else:
+                posts_to_cache = []
+        elif isinstance(response, dict):
+            if self.convert_npf_to_legacy_html and "posts" in response:
+                response["posts"] = [simulate_legacy_payload(p) for p in response["posts"]]
+            posts_to_cache = response.get("posts", [])
 
-        if self.convert_npf_to_legacy_html and "posts" in response:
-            response["posts"] = [simulate_legacy_payload(p) for p in response["posts"]]
-
-        for post_payload in response.get("posts", []):
+        for post_payload in posts_to_cache:
             post_identifier = PostIdentifier(post_payload["blog"]["name"], post_payload["id"])
             self.reblog_requirements_cache[post_identifier] = {
                 "reblog_key": post_payload["reblog_key"],

--- a/tests/test_pytumblr.py
+++ b/tests/test_pytumblr.py
@@ -240,10 +240,10 @@ class TumblrRestClientTest(unittest.TestCase):
 
     @mock.patch('requests.get')
     def test_tagged(self, mock_get):
-        mock_get.side_effect = wrap_response('{"meta": {"status": 200, "msg": "OK"}, "response": {}}')
+        mock_get.side_effect = wrap_response('{"meta": {"status": 200, "msg": "OK"}, "response": []}')
 
         response = self.client.tagged('food')
-        assert response == {}
+        assert response == []
 
     @mock.patch('requests.post')
     def test_legacy_create_text(self, mock_post):


### PR DESCRIPTION
The `send_api_request` method is written under the assumption that the API response will always be a JSON object. Unfortunately, the `/tagged` endpoint returns a JSON array, and so calling the `TumblrRestClient.tagged` method throws an exception on line 750 at `response.get("posts", [])` since lists don't have a `get` method.

This PR fixes that by checking if the response type is a list or a dict, and handling it appropriately either way. I am not aware of any other API endpoint that returns an array (though I didn't look very hard), so I am not sure if the contents of an array returned from the API will always be post objects, so I included a check to see if the list contents look like posts before treating them as such. This is probably unnecessary but it seemed like a reasonable safety measure.

As for testing, I updated the mock in the unit test for the tagged method to correctly return an array (this causes the test to break without my change; my change causes it to pass again), and all unit tests pass. Outside of unit testing, I verified that I am now able to call the `TumblrRestClient.tagged` method and receive a list of tagged posts. I didn't perform extensive regression testing, but I verified that the `TumblrRestClient.dashboard` and `TumblrRestClient.likes` methods still work as before.

This is my first time making a PR to an open source project, so 1) wahoo! and 2) please let me know if I've done anything wrong in setting this up; I find the whole process kind of confusing. Also, PS - your `CONTRIBUTING.md` file hasn't been updated since forking and requires submitting a CLA at a now-dead link that references Yahoo.