### PR TITLE
allow byte-based media sources

### DIFF
--- a/pytumblr2/__init__.py
+++ b/pytumblr2/__init__.py
@@ -732,11 +732,11 @@ class TumblrRestClient(object):
 
         if "media_sources" in params:
             # media uploads for NPF media blocks
-            ks = list(params["media_sources"].keys())
-            for k in ks:
-                if isinstance(k, str):
+            sources = params["media_sources"].items()
+            for k, v in sources:
+                if isinstance(v, str):
                     # got file path, need file object
-                    params["media_sources"][k] = open(params["media_sources"][k], "rb")
+                    params["media_sources"][k] = open(params["media_sources"][v], "rb")
 
         if method == "get":
             response = self.request.get(url, params)


### PR DESCRIPTION
Greetings, and first of all thank you for updating and maintaining this library!

While working on a project, I noticed that trying to send a bytes object as a media source, resulted in an `ValueError: embedded null byte` error. Investigating this, I found that this is caused by the way media sources are handled in the api request method. The "key" value representing the media identifier is (at least according to the spec) always a string, which makes the instance check obsolete and pipes every kind of value into the `open` built-in. But taking the comment below into consideration this should actually be the case for the value which can either hold a string containing the path or a bytes object.

This way it works in my project, and I would like to contribute it back, if you'd like :)

(Also I would have tried to open an issue first, but it seems like they are disabled for this repo (Maybe automatically by github?!))

Kind regards,
Breuxi